### PR TITLE
Use .env configuration file to configure endpoint

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,13 +10,14 @@ import {
     InMemoryCache,
 } from '@apollo/client';
 
+import { api } from '#config';
+
 import App from './App';
 
 const webappRootId = 'webapp-root';
 const webappRootElement = document.getElementById(webappRootId);
-const APP_GRAPHQL_ENDPOINT = 'http://localhost:8000/graphql/';
 const client = new ApolloClient({
-    uri: APP_GRAPHQL_ENDPOINT,
+    uri: api,
     cache: new InMemoryCache(),
 });
 if (!webappRootElement) {


### PR DESCRIPTION
Let's not use configuration directly as done here previously. I have reverted the changes made. Also, this should have been caught in the PR reviews. :smile: 
cc @barshathakuri @roshni73 
Let's always use to .env file to configure.


## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
