### PR TITLE
make ingressClassName configurable in helm chart

### DIFF
--- a/nginx-serve/helm/templates/ingress.yaml
+++ b/nginx-serve/helm/templates/ingress.yaml
@@ -19,3 +19,9 @@ spec:
                 name: {{ template "ifrcgo-web-app.fullname" . }}-svc
                 port:
                   number: 80
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ required "ingress.tls.secretName" .Values.ingress.tls.secretName }}
+  {{- end }}

--- a/nginx-serve/helm/templates/ingress.yaml
+++ b/nginx-serve/helm/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     environment: {{ .Values.environment }}
     release: {{ .Release.Name }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ required "ingress.className" .Values.ingress.className | quote }}
   rules:
     - host: {{ required "ingress.host" .Values.ingress.host | quote }}
       http:

--- a/nginx-serve/helm/values-production.yaml
+++ b/nginx-serve/helm/values-production.yaml
@@ -1,6 +1,10 @@
 # NOTE: go-deploy can override or add additional configs https://github.com/IFRCGo/go-deploy
 environment: production
 
+ingress:
+  tls:
+    enabled: true
+
 env:
   APP_ENVIRONMENT: production
   APP_MAPBOX_ACCESS_TOKEN: pk.eyJ1IjoiZ28taWZyYyIsImEiOiJjams3b2ZhZWswMGFvM3hxeHp2ZHFhOTRrIn0._pqO9OQ2iNeDGrpopJNjpg

--- a/nginx-serve/helm/values-staging.yaml
+++ b/nginx-serve/helm/values-staging.yaml
@@ -1,6 +1,10 @@
 # NOTE: go-deploy can override or add additional configs https://github.com/IFRCGo/go-deploy
 environment: staging
 
+ingress:
+  tls:
+    enabled: true
+
 env:
   APP_ENVIRONMENT: staging
   APP_MAPBOX_ACCESS_TOKEN: pk.eyJ1IjoiZ28taWZyYyIsImEiOiJjams3b2ZhZWswMGFvM3hxeHp2ZHFhOTRrIn0._pqO9OQ2iNeDGrpopJNjpg

--- a/nginx-serve/helm/values-test.yaml
+++ b/nginx-serve/helm/values-test.yaml
@@ -7,6 +7,7 @@ image:
 
 ingress:
   host: alert-hub-1.ifrc-go.org
+  className: nginx
 
 env:
   APP_TITLE: "Alert hub"

--- a/nginx-serve/helm/values.yaml
+++ b/nginx-serve/helm/values.yaml
@@ -15,6 +15,7 @@ resources:
 
 ingress:
   host:
+  className: 
 
 env:
   APP_TITLE: "Alert hub"

--- a/nginx-serve/helm/values.yaml
+++ b/nginx-serve/helm/values.yaml
@@ -15,7 +15,10 @@ resources:
 
 ingress:
   host:
-  className: 
+  className:
+  tls:
+    enabled: false
+    secretName:
 
 env:
   APP_TITLE: "Alert hub"


### PR DESCRIPTION
This change allows ingress deployment in a cluster where the 'nginx' ingress class is unavailable.